### PR TITLE
Update gender.go

### DIFF
--- a/pkg/model/gender.go
+++ b/pkg/model/gender.go
@@ -5,5 +5,6 @@ type Gender string
 const (
 	GenderMale         Gender = "male"
 	GenderFemale              = "female"
+	GenderDivers              = "divers"
 	GenderNotSpecified        = "not specified"
 )


### PR DESCRIPTION
Da Divers und nicht nicht spezifiziert zwei verschiedene Sachen sind und seit letztem Jahr Divers offiziell anerkannt ist, sollte hierauf Rücksicht genommen werden. Leider viel mir keine gescheite Englische Übersetzung ein, da man im englischen ja eher ein Dutzende/Siezende Umgang führt.

"Seit dem 22. Dezember 2018 besteht die Möglichkeit, im Personenstandsregister die Angabe „divers“ eintragen zu lassen. Zusammen mit Personen, deren Geschlecht rechtlich offen gelassen wurde, gelten sie nach dem deutschen Personenstandsgesetz als „weder dem weiblichen noch dem männlichen Geschlecht zugeordnet“ (PStG: § 22, Absatz 3).[3] Die im Folgenden aufgeführten Regelungen gelten deshalb gleichermaßen für diese beiden Teilgruppen, soweit sie nicht jeweils einzeln genannt sind."  Quelle: https://de.wikipedia.org/wiki/Divers